### PR TITLE
Add settings screen with privacy policy and terms

### DIFF
--- a/CLex.html
+++ b/CLex.html
@@ -225,7 +225,7 @@
                             </ul>
                             <p class="text-gray-700 dark:text-gray-300 mt-3">Most of your data, including favorites and learning progress, is stored locally on your device and is not transmitted to our servers unless you explicitly choose to sync across devices.</p>
 
-                            <h4 class="font-semibold text-gray-800 dark:text-gray-2 00 mt-6 mb-2">Your Rights</h4>
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Your Rights</h4>
                             <ul class="list-disc pl-6 space-y-1 text-gray-700 dark:text-gray-300 mb-3">
                                 <li>Access your personal data</li>
                                 <li>Correct inaccurate information</li>

--- a/CLex.html
+++ b/CLex.html
@@ -183,6 +183,61 @@
                     </div>
                 </div>
             </div>
+            <!-- Settings Screen -->
+            <div id="settingsScreen" class="h-full hidden">
+                <div class="h-full overflow-y-auto">
+                    <div class="max-w-4xl mx-auto p-4">
+                        <div class="mb-6">
+                            <h2 class="text-2xl font-bold">Settings</h2>
+                            <p class="text-gray-600 dark:text-gray-400">Manage your preferences and privacy</p>
+                        </div>
+
+                        <section aria-labelledby="privacy-policy-title" class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm border border-gray-200 dark:border-gray-700">
+                            <h3 id="privacy-policy-title" class="text-xl font-semibold mb-4">Privacy Policy</h3>
+                            <p class="text-gray-700 dark:text-gray-300 mb-4">Your privacy is important to us. This policy explains how we collect, use, and protect your information.</p>
+
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Information We Collect</h4>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">ChakmaLex is committed to protecting your privacy. We collect minimal information necessary to provide our services:</p>
+                            <ul class="list-disc pl-6 space-y-1 text-gray-700 dark:text-gray-300">
+                                <li>Search queries to improve dictionary functionality</li>
+                                <li>Favorite words and learning progress (stored locally)</li>
+                                <li>Usage analytics to enhance user experience</li>
+                                <li>Account information if you choose to create an account</li>
+                            </ul>
+
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">How We Use Your Information</h4>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">We use the information we collect to:</p>
+                            <ul class="list-disc pl-6 space-y-1 text-gray-700 dark:text-gray-300">
+                                <li>Provide and improve our dictionary services</li>
+                                <li>Personalize your learning experience</li>
+                                <li>Save your preferences and progress</li>
+                                <li>Communicate with you about updates and features</li>
+                                <li>Ensure the security and proper functioning of our platform</li>
+                            </ul>
+
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Data Protection</h4>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">We implement appropriate security measures to protect your personal information:</p>
+                            <ul class="list-disc pl-6 space-y-1 text-gray-700 dark:text-gray-300">
+                                <li>Secure data transmission using encryption</li>
+                                <li>Regular security audits and updates</li>
+                                <li>Limited access to personal information</li>
+                                <li>Data minimization practices</li>
+                            </ul>
+                            <p class="text-gray-700 dark:text-gray-300 mt-3">Most of your data, including favorites and learning progress, is stored locally on your device and is not transmitted to our servers unless you explicitly choose to sync across devices.</p>
+
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-2 00 mt-6 mb-2">Your Rights</h4>
+                            <ul class="list-disc pl-6 space-y-1 text-gray-700 dark:text-gray-300 mb-3">
+                                <li>Access your personal data</li>
+                                <li>Correct inaccurate information</li>
+                                <li>Delete your account and associated data</li>
+                                <li>Export your data</li>
+                                <li>Opt out of analytics tracking</li>
+                            </ul>
+                            <p class="text-gray-700 dark:text-gray-300">To exercise these rights or if you have any privacy concerns, please contact us at <a href="mailto:ujclnove@gmail.com" class="text-primary hover:text-primary-dark underline">ujclnove@gmail.com</a></p>
+                        </section>
+                    </div>
+                </div>
+            </div>
         </main>
 
         <!-- Bottom Navigation -->
@@ -197,7 +252,7 @@
                         <i class="fas fa-heart text-xl mb-1"></i>
                         <span class="text-xs">Favorites</span>
                     </button>
-                    <button id="settingsBtn" class="nav-btn flex flex-col items-center py-3 px-4 text-gray-400" aria-label="Settings">
+                    <button id="settingsBtn" class="nav-btn flex flex-col items-center py-3 px-4 text-gray-400" aria-label="Settings" data-screen="settings">
                         <i class="fas fa-cog text-xl mb-1"></i>
                         <span class="text-xs">Settings</span>
                     </button>

--- a/CLex.html
+++ b/CLex.html
@@ -322,6 +322,10 @@
                         <i class="fas fa-heart text-xl mb-1"></i>
                         <span class="text-xs">Favorites</span>
                     </button>
+                    <button class="nav-btn flex flex-col items-center py-3 px-4 text-gray-400" data-screen="more">
+                        <i class="fas fa-ellipsis-h text-xl mb-1"></i>
+                        <span class="text-xs">More</span>
+                    </button>
                     <button id="settingsBtn" class="nav-btn flex flex-col items-center py-3 px-4 text-gray-400" aria-label="Settings" data-screen="settings">
                         <i class="fas fa-cog text-xl mb-1"></i>
                         <span class="text-xs">Settings</span>

--- a/CLex.html
+++ b/CLex.html
@@ -192,7 +192,16 @@
                             <p class="text-gray-600 dark:text-gray-400">Manage your preferences and privacy</p>
                         </div>
 
-                        <section aria-labelledby="privacy-policy-title" class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm border border-gray-200 dark:border-gray-700">
+                        <!-- Settings Tabs -->
+                        <div class="mb-6">
+                            <div class="flex space-x-2 bg-gray-100 dark:bg-gray-700 p-1 rounded-lg">
+                                <button data-settings-tab="privacySection" class="settings-tab bg-white dark:bg-gray-600 text-primary dark:text-primary px-4 py-2 rounded-md text-sm font-medium">Privacy Policy</button>
+                                <button data-settings-tab="termsSection" class="settings-tab text-gray-600 dark:text-gray-300 px-4 py-2 rounded-md text-sm font-medium">Terms &amp; Conditions</button>
+                            </div>
+                        </div>
+
+                        <!-- Privacy Policy -->
+                        <section id="privacySection" aria-labelledby="privacy-policy-title" class="settings-section bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm border border-gray-200 dark:border-gray-700">
                             <h3 id="privacy-policy-title" class="text-xl font-semibold mb-4">Privacy Policy</h3>
                             <p class="text-gray-700 dark:text-gray-300 mb-4">Your privacy is important to us. This policy explains how we collect, use, and protect your information.</p>
 
@@ -234,6 +243,67 @@
                                 <li>Opt out of analytics tracking</li>
                             </ul>
                             <p class="text-gray-700 dark:text-gray-300">To exercise these rights or if you have any privacy concerns, please contact us at <a href="mailto:ujclnove@gmail.com" class="text-primary hover:text-primary-dark underline">ujclnove@gmail.com</a></p>
+                        </section>
+
+                        <!-- Terms & Conditions -->
+                        <section id="termsSection" aria-labelledby="terms-title" class="settings-section hidden bg-white dark:bg-gray-800 rounded-xl p-6 shadow-sm border border-gray-200 dark:border-gray-700">
+                            <h3 id="terms-title" class="text-xl font-semibold mb-4">Terms &amp; Conditions</h3>
+
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">Please read these terms and conditions carefully before using ChakmaLex.</p>
+
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-200 mt-4 mb-2">Acceptance of Terms</h4>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">By accessing and using ChakmaLex, you accept and agree to be bound by the terms and provision of this agreement.</p>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">ChakmaLex is a digital dictionary platform dedicated to preserving and promoting the Chakma language. These terms govern your use of our services, features, and content.</p>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">If you do not agree to abide by the above, please do not use this service.</p>
+
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-200 mt-4 mb-2">Use of the Service</h4>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">ChakmaLex is provided for educational, cultural, and linguistic purposes. You may use our service to:</p>
+                            <ul class="list-disc pl-6 space-y-1 text-gray-700 dark:text-gray-300">
+                                <li>Search and explore Chakma language dictionary entries</li>
+                                <li>Learn Chakma language through our educational features</li>
+                                <li>Save favorite words and track learning progress</li>
+                                <li>Participate in language quizzes and challenges</li>
+                                <li>Access pronunciation guides and cultural information</li>
+                            </ul>
+                            <p class="text-gray-700 dark:text-gray-300 mt-3">You agree not to use ChakmaLex for any unlawful or prohibited activities, including but not limited to: distributing malicious content, attempting to compromise system security, or using automated tools to access our services excessively.</p>
+
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-200 mt-4 mb-2">Content and Intellectual Property</h4>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">The content on ChakmaLex, including dictionary entries, translations, pronunciations, and cultural information, is provided for educational and cultural preservation purposes.</p>
+                            <ul class="list-disc pl-6 space-y-1 text-gray-700 dark:text-gray-300 mb-3">
+                                <li>Content is curated through scholarly research and community collaboration</li>
+                                <li>Users may reference and cite our content for educational purposes</li>
+                                <li>Commercial use requires explicit permission</li>
+                                <li>We respect the intellectual property rights of others</li>
+                                <li>Users retain rights to their personal data and learning progress</li>
+                            </ul>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">If you believe any content infringes on your rights, please contact us immediately for resolution.</p>
+
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-200 mt-4 mb-2">User Accounts and Data</h4>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">When you create an account or use our services:</p>
+                            <ul class="list-disc pl-6 space-y-1 text-gray-700 dark:text-gray-300 mb-3">
+                                <li>You are responsible for maintaining account security</li>
+                                <li>Your learning progress and favorites are stored locally by default</li>
+                                <li>We may collect usage analytics to improve our services</li>
+                                <li>You can delete your account and data at any time</li>
+                                <li>We do not sell your personal information to third parties</li>
+                            </ul>
+                            <p class="text-gray-700 dark:text-gray-300">For detailed information about data handling, please refer to our Privacy Policy.</p>
+
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-200 mt-4 mb-2">Disclaimers and Limitations</h4>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">ChakmaLex is provided "as is" without warranties of any kind. While we strive for accuracy:</p>
+                            <ul class="list-disc pl-6 space-y-1 text-gray-700 dark:text-gray-300 mb-3">
+                                <li>Dictionary content may contain errors or omissions</li>
+                                <li>Services may be temporarily unavailable for maintenance</li>
+                                <li>We are not liable for decisions made based on our content</li>
+                                <li>Language learning results may vary by individual</li>
+                                <li>We reserve the right to modify or discontinue features</li>
+                            </ul>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">For questions about accuracy or content, please contact our editorial team.</p>
+
+                            <h4 class="font-semibold text-gray-800 dark:text-gray-200 mt-4 mb-2">Changes to Terms</h4>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">We may update these terms periodically to reflect changes in our services or legal requirements.</p>
+                            <p class="text-gray-700 dark:text-gray-300 mb-3">Users will be notified of significant changes, and continued use of ChakmaLex constitutes acceptance of updated terms.</p>
+                            <p class="text-gray-700 dark:text-gray-300">For questions about these terms, please contact us at <a href="mailto:ujclnove@gmail.com" class="text-primary hover:text-primary-dark underline">ujclnove@gmail.com</a></p>
                         </section>
                     </div>
                 </div>
@@ -770,6 +840,24 @@ Morning dew is ephemeral, disappearing with the sunrise." class="w-full text-bas
 
             settingsBtn.addEventListener('touchend', () => {
                 clearTimeout(pressTimer);
+            });
+
+            // Settings tabs inside settings screen
+            document.querySelectorAll('[data-settings-tab]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const target = btn.dataset.settingsTab;
+                    document.querySelectorAll('.settings-section').forEach(s => s.classList.add('hidden'));
+                    const el = document.getElementById(target);
+                    if (el) el.classList.remove('hidden');
+
+                    // update active styles
+                    document.querySelectorAll('[data-settings-tab]').forEach(b => {
+                        b.classList.remove('bg-white','dark:bg-gray-600','text-primary','dark:text-primary');
+                        b.classList.add('text-gray-600','dark:text-gray-300');
+                    });
+                    btn.classList.add('bg-white','dark:bg-gray-600','text-primary','dark:text-primary');
+                    btn.classList.remove('text-gray-600','dark:text-gray-300');
+                });
             });
 
             // Modal functionality

--- a/CLex.html
+++ b/CLex.html
@@ -885,6 +885,37 @@ Morning dew is ephemeral, disappearing with the sunrise." class="w-full text-bas
                 });
             });
 
+            // More screen buttons
+            const moreSettingsBtn = document.getElementById('moreSettingsBtn');
+            const morePrivacyBtn = document.getElementById('morePrivacyBtn');
+            const moreTermsBtn = document.getElementById('moreTermsBtn');
+            const moreDevConsoleBtn = document.getElementById('moreDevConsoleBtn');
+
+            if (moreSettingsBtn) {
+                moreSettingsBtn.addEventListener('click', () => {
+                    switchScreen('settings');
+                });
+            }
+            if (morePrivacyBtn) {
+                morePrivacyBtn.addEventListener('click', () => {
+                    switchScreen('settings');
+                    const privacyTab = document.querySelector('[data-settings-tab="privacySection"]');
+                    if (privacyTab) privacyTab.click();
+                });
+            }
+            if (moreTermsBtn) {
+                moreTermsBtn.addEventListener('click', () => {
+                    switchScreen('settings');
+                    const termsTab = document.querySelector('[data-settings-tab="termsSection"]');
+                    if (termsTab) termsTab.click();
+                });
+            }
+            if (moreDevConsoleBtn) {
+                moreDevConsoleBtn.addEventListener('click', () => {
+                    openDevConsole();
+                });
+            }
+
             // Modal functionality
             setupModalListeners();
 

--- a/CLex.html
+++ b/CLex.html
@@ -308,6 +308,27 @@
                     </div>
                 </div>
             </div>
+
+            <!-- More Screen -->
+            <div id="moreScreen" class="h-full hidden">
+                <div class="h-full overflow-y-auto">
+                    <div class="max-w-4xl mx-auto p-4">
+                        <div class="mb-6">
+                            <h2 class="text-2xl font-bold">More</h2>
+                            <p class="text-gray-600 dark:text-gray-400">Additional options and links</p>
+                        </div>
+
+                        <div class="grid gap-3">
+                            <button id="moreSettingsBtn" class="w-full text-left px-4 py-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700">Open Settings</button>
+                            <button id="morePrivacyBtn" class="w-full text-left px-4 py-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700">Privacy Policy</button>
+                            <button id="moreTermsBtn" class="w-full text-left px-4 py-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700">Terms &amp; Conditions</button>
+                            <button id="moreDevConsoleBtn" class="w-full text-left px-4 py-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700">Developer Console</button>
+                            <a href="mailto:ujclnove@gmail.com" class="w-full block px-4 py-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 text-left">Contact Us</a>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
         </main>
 
         <!-- Bottom Navigation -->


### PR DESCRIPTION
## Purpose

The user requested to add comprehensive legal documentation and navigation improvements to the ChakmaLex dictionary app. They wanted to:

1. Add a Privacy Policy section explaining data collection, usage, protection measures, and user rights
2. Add Terms & Conditions covering service usage, content policies, user accounts, and legal disclaimers  
3. Add a "More" navigation option to provide additional app functionality and quick access to settings

## Code Changes

- **Added Settings Screen**: Created a new settings interface with tabbed navigation between Privacy Policy and Terms & Conditions sections
- **Privacy Policy**: Implemented comprehensive privacy documentation covering data collection, usage, protection, and user rights with contact information
- **Terms & Conditions**: Added detailed terms covering service acceptance, usage guidelines, content policies, user accounts, disclaimers, and legal provisions
- **More Screen**: Created new "More" navigation section with buttons for Settings, Privacy Policy, Terms & Conditions, Developer Console, and Contact Us
- **Navigation Updates**: Updated bottom navigation to include "More" option alongside existing Search, Favorites, and Settings buttons
- **Interactive Features**: Added tab switching functionality for settings sections and navigation between screens
- **Responsive Design**: Implemented proper styling with dark mode support and mobile-friendly layoutTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6b6ffc246be54918833fc34a594b63a7/flare-haven)

👀 [Preview Link](https://6b6ffc246be54918833fc34a594b63a7-flare-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6b6ffc246be54918833fc34a594b63a7</projectId>-->
<!--<branchName>flare-haven</branchName>-->